### PR TITLE
Restore header rendering and reset pagination state

### DIFF
--- a/catalogo_pdf/render/builder.py
+++ b/catalogo_pdf/render/builder.py
@@ -27,6 +27,7 @@ class CatalogoRenderizador:
 
     def renderizar(self, catalogo: Catalogo, ruta_pdf: str) -> None:
         """Genera un PDF ubicando las categorias y productos en paginas."""
+        self._pagina_iniciada = False
         preparar_fuentes(self.configuracion)
         lienzo = canvas.Canvas(str(Path(ruta_pdf)), pagesize=A4)
         ancho_pagina, alto_pagina = A4
@@ -54,7 +55,12 @@ class CatalogoRenderizador:
         else:
             self._pagina_iniciada = True
         dibujar_encabezado(lienzo, self.configuracion)
-        return alto_pagina - self.configuracion.margen_y - self.configuracion.altura_encabezado - self.configuracion.separacion_encabezado
+        return (
+            alto_pagina
+            - self.configuracion.margen_y
+            - self.configuracion.altura_encabezado
+            - self.configuracion.separacion_encabezado
+        )
 
     def _renderizar_categoria(
         self,
@@ -68,7 +74,11 @@ class CatalogoRenderizador:
     ) -> float:
         configuracion = self.configuracion
         icono = categoria.icono_predeterminado
-        altura_requerida = configuracion.altura_banner_categoria + configuracion.altura_minima_tarjeta + configuracion.separacion_filas
+        altura_requerida = (
+            configuracion.altura_banner_categoria
+            + configuracion.altura_minima_tarjeta
+            + configuracion.separacion_filas
+        )
 
         if y_cursor - altura_requerida < configuracion.margen_y:
             y_cursor = self._iniciar_pagina(lienzo, alto_pagina)

--- a/catalogo_pdf/render/header.py
+++ b/catalogo_pdf/render/header.py
@@ -90,7 +90,7 @@ def dibujar_encabezado(lienzo: CanvasTipo, configuracion: LayoutConfig) -> None:
         altura_apr,
         anchor="right",
     )
-"""
+
     titulo = configuracion.titulo_encabezado
     lienzo.setFont(configuracion.fuente_encabezado, configuracion.tamano_marca_encabezado)
     #lienzo.setFillColor(colors.white)
@@ -99,10 +99,14 @@ def dibujar_encabezado(lienzo: CanvasTipo, configuracion: LayoutConfig) -> None:
         centro_y - configuracion.tamano_marca_encabezado / 3,
         titulo,
     )
-""""""
+
     lienzo.setStrokeColor(configuracion.color_secundario)
     lienzo.setLineWidth(1.2)
-    lienzo.line(configuracion.margen_x, limite_inferior, ancho_pagina - configuracion.margen_x, limite_inferior)
+    lienzo.line(
+        configuracion.margen_x,
+        limite_inferior,
+        ancho_pagina - configuracion.margen_x,
+        limite_inferior,
+    )
     lienzo.restoreState()
-"""
 


### PR DESCRIPTION
## Summary
- restore the header drawing instructions so the title and divider render and the canvas state is restored
- reset the pagination flag at the start of each render call and clarify layout calculations to avoid blank first pages

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'catalogo_pdf'; ModuleNotFoundError: No module named 'reportlab')*

------
https://chatgpt.com/codex/tasks/task_e_68d9cb11eeb883228b60fabd6860bf58